### PR TITLE
Update FlagSecurePackage.java

### DIFF
--- a/android/src/main/java/com/kristiansorens/flagsecure/FlagSecurePackage.java
+++ b/android/src/main/java/com/kristiansorens/flagsecure/FlagSecurePackage.java
@@ -21,11 +21,6 @@ public class FlagSecurePackage implements ReactPackage {
     }
 
     @Override
-    public List<Class<? extends JavaScriptModule>> createJSModules() {
-        return Collections.emptyList();
-    }
-
-    @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
         return new ArrayList<>();
     }


### PR DESCRIPTION
createJSModules is deprecated in React native 0.47.0
We need to remove it in order to integrate your plugin in our project